### PR TITLE
Make product sizes into separate model

### DIFF
--- a/app/controllers/admin_console/products_controller.rb
+++ b/app/controllers/admin_console/products_controller.rb
@@ -52,13 +52,14 @@ module AdminConsole
     def product_params
       product_params = params.require(:product).permit(
         :name,
-        :price,
         :detail,
-        :quantity,
         :featured,
         :category_id,
-        variations_attributes: %i[name image price],
-        sizes_attributes: %i[size price width length height],
+        variations_attributes: [
+          :name,
+          :image,
+          sizes_attributes: %i[size price length width height]
+        ],
         images: [],
       )
 

--- a/app/controllers/admin_console/products_controller.rb
+++ b/app/controllers/admin_console/products_controller.rb
@@ -58,7 +58,7 @@ module AdminConsole
         variations_attributes: [
           :name,
           :image,
-          sizes_attributes: %i[size price length width height]
+          sizes_attributes: %i[size price weight quantity length width height],
         ],
         images: [],
       )

--- a/app/controllers/admin_console/products_controller.rb
+++ b/app/controllers/admin_console/products_controller.rb
@@ -55,9 +55,10 @@ module AdminConsole
         :price,
         :detail,
         :quantity,
+        :featured,
         :category_id,
-        sizes: [],
-        variations_attributes: %i[name image],
+        variations_attributes: %i[name image price],
+        sizes_attributes: %i[size price width length height],
         images: [],
       )
 

--- a/app/javascript/controllers/previews_controller.js
+++ b/app/javascript/controllers/previews_controller.js
@@ -38,7 +38,6 @@ export default class extends Controller {
     let image = document.createElement('img')
     image.setAttribute('src', reader.result)
     // image.setAttribute('width', 150)
-    image.setAttribute('class', 'border')
 
     preview.appendChild(image)
   }
@@ -51,7 +50,7 @@ export default class extends Controller {
     
     let image = document.createElement('img')
     image.setAttribute('src', e.currentTarget.src)
-    image.setAttribute('class', 'border mx-auto h-54 max-h-full')
+    image.setAttribute('class', 'mx-auto h-54 max-h-full')
     preview.appendChild(image)
   }
 

--- a/app/javascript/controllers/products_controller.js
+++ b/app/javascript/controllers/products_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
   ]
 
   connect() {
-    // console.log('hello products')
+    // console.log(this.sizesContainerTarget)
   }
 
   selectColor() {
@@ -43,23 +43,45 @@ export default class extends Controller {
     }
   }
 
-  addSize(e) {
-    e.preventDefault();
+  addSizeFields(e) {
+    if(e) e.preventDefault();
 
-    const sizeField = document.createElement('input')
-    sizeField.setAttribute('type', 'text')
-    sizeField.setAttribute('name', 'product[sizes][]')
-    sizeField.setAttribute('class', 'm-1 w-1/3 border-gray-700 border-0 border-b-2 bg-gray-50')
+    const sizeField = this.createSizeField('text', 'size')
     sizeField.setAttribute('required', 'true')
-    sizeField.addEventListener('keydown', (e) => {
-      const key = e.code
-      const value = e.currentTarget.value
-      if (value.length > 0) return
-      if(key == 'Backspace') sizeField.remove()
-    })
-    const container = this.sizesContainerTarget;
+    const priceField = this.createSizeField('number', 'price')
 
-    container.appendChild(sizeField)
+    const mainDetails = document.createElement('div')
+    mainDetails.setAttribute('class', 'flex m-1')
+    mainDetails.appendChild(sizeField)
+    mainDetails.appendChild(priceField)
+
+    const widthField = this.createSizeField('number', 'width')
+    const lengthField = this.createSizeField('number', 'length')
+    const heightField = this.createSizeField('number', 'height')
+  
+    const dimensions = document.createElement('div')
+    dimensions.setAttribute('class', 'flex m-1')
+    dimensions.appendChild(lengthField)
+    dimensions.appendChild(widthField)
+    dimensions.appendChild(heightField)
+    
+    const div = document.createElement('div')
+    div.setAttribute('class', 'relative border rounded p-2')
+    div.appendChild(mainDetails)
+    div.appendChild(dimensions)
+
+    const cancelButton = document.createElement('span')
+    cancelButton.setAttribute('class', 'absolute -top-4 -right-4 ml-2 p-1 flex items-center justify-center rounded-full text-white bg-gray-300 hover:bg-gray-400 shadow hover:cursor-pointer')
+    cancelButton.style.width = '2rem'
+    cancelButton.style.height = '2rem'
+    cancelButton.innerText = 'x'
+    cancelButton.addEventListener('click', (e) => {
+      div.remove()
+    })
+
+    div.appendChild(cancelButton)
+    const container = this.sizesContainerTarget;
+    container.appendChild(div)
   }
 
   removeField(e, sizeField) {
@@ -112,5 +134,23 @@ export default class extends Controller {
     })
 
     this.variationContainerTarget.appendChild(div)
+  }
+
+  createSizeField(type, name) {
+    const input = document.createElement('input')
+    input.setAttribute('type', type)
+    
+    if(['length', 'width', 'height'].includes(name)) {
+      input.setAttribute('placeholder', `${name} (cm)`)
+    } else {
+      input.setAttribute('placeholder', name)
+    }
+
+    if(type == 'number') input.setAttribute('step', 'any')
+
+    input.setAttribute('name', `product[sizes_attributes][][${name}]`)
+    input.setAttribute('class', 'mx-2 border rounded')
+
+    return input
   }
 }

--- a/app/javascript/controllers/products_controller.js
+++ b/app/javascript/controllers/products_controller.js
@@ -6,8 +6,6 @@ export default class extends Controller {
     'colorPicker',
     'colorGroup',
     'imageGroup',
-    'sizesContainer',
-    'variationContainer'
   ]
 
   connect() {
@@ -41,116 +39,5 @@ export default class extends Controller {
         this.imageGroupTarget.removeAttribute('hidden')
         break;
     }
-  }
-
-  addSizeFields(e) {
-    if(e) e.preventDefault();
-
-    const sizeField = this.createSizeField('text', 'size')
-    sizeField.setAttribute('required', 'true')
-    const priceField = this.createSizeField('number', 'price')
-
-    const mainDetails = document.createElement('div')
-    mainDetails.setAttribute('class', 'flex m-1')
-    mainDetails.appendChild(sizeField)
-    mainDetails.appendChild(priceField)
-
-    const widthField = this.createSizeField('number', 'width')
-    const lengthField = this.createSizeField('number', 'length')
-    const heightField = this.createSizeField('number', 'height')
-  
-    const dimensions = document.createElement('div')
-    dimensions.setAttribute('class', 'flex m-1')
-    dimensions.appendChild(lengthField)
-    dimensions.appendChild(widthField)
-    dimensions.appendChild(heightField)
-    
-    const div = document.createElement('div')
-    div.setAttribute('class', 'relative border rounded p-2')
-    div.appendChild(mainDetails)
-    div.appendChild(dimensions)
-
-    const cancelButton = document.createElement('span')
-    cancelButton.setAttribute('class', 'absolute -top-4 -right-4 ml-2 p-1 flex items-center justify-center rounded-full text-white bg-gray-300 hover:bg-gray-400 shadow hover:cursor-pointer')
-    cancelButton.style.width = '2rem'
-    cancelButton.style.height = '2rem'
-    cancelButton.innerText = 'x'
-    cancelButton.addEventListener('click', (e) => {
-      div.remove()
-    })
-
-    div.appendChild(cancelButton)
-    const container = this.sizesContainerTarget;
-    container.appendChild(div)
-  }
-
-  removeField(e, sizeField) {
-    const key = e.code
-    const value = e.currentTarget.value
-    if (value.length > 0) return
-
-    if(key == 'Backspace' && sizeField) return sizeField.remove()
-
-    if(key == 'Backspace') return e.currentTarget.remove()
-  }
-
-  addVariationField(e){
-    e.preventDefault()
-    const nameInput = document.createElement('input')
-    nameInput.setAttribute('type', 'text')
-    nameInput.setAttribute('name', 'product[variations_attributes][][name]')
-    nameInput.setAttribute('placeholder', 'Input name...')
-    nameInput.setAttribute('class', 'border-0 border-b-2 border-black mr-5 text-base h-14')
-
-    const imageInput = document.createElement('input')
-    imageInput.setAttribute('type', 'file')
-    imageInput.setAttribute('name', 'product[variations_attributes][][image]')
-    imageInput.setAttribute('accept', 'image/png, image/jpeg')
-    imageInput.setAttribute('class', 'variation-image-input')
-
-    const priceInput = document.createElement('input')
-    priceInput.setAttribute('type', 'number')
-    priceInput.setAttribute('step', 'any')
-    priceInput.setAttribute('name', 'product[variations_attributes][][price]')
-    priceInput.setAttribute('placeholder', 'Input price...')
-    priceInput.setAttribute('class', 'border-0 border-b-2 border-black mr-5 text-base h-14')
-
-    const cancelButton = document.createElement('span')
-    cancelButton.setAttribute('class', 'absolute -top-4 -right-4 ml-2 p-1 flex items-center justify-center rounded-full text-white bg-gray-300 hover:bg-gray-400 shadow hover:cursor-pointer')
-    cancelButton.style.width = '2rem'
-    cancelButton.style.height = '2rem'
-    cancelButton.innerText = 'x'
-  
-    const div = document.createElement('div')
-    div.setAttribute('class', 'relative m-2 flex items-center justify-around')
-    div.appendChild(nameInput)
-    div.appendChild(priceInput)
-    div.appendChild(imageInput)
-    div.appendChild(cancelButton)
-    
-
-    cancelButton.addEventListener('click', (e) => {
-      div.remove()
-    })
-
-    this.variationContainerTarget.appendChild(div)
-  }
-
-  createSizeField(type, name) {
-    const input = document.createElement('input')
-    input.setAttribute('type', type)
-    
-    if(['length', 'width', 'height'].includes(name)) {
-      input.setAttribute('placeholder', `${name} (cm)`)
-    } else {
-      input.setAttribute('placeholder', name)
-    }
-
-    if(type == 'number') input.setAttribute('step', 'any')
-
-    input.setAttribute('name', `product[sizes_attributes][][${name}]`)
-    input.setAttribute('class', 'mx-2 border rounded')
-
-    return input
   }
 }

--- a/app/javascript/controllers/variation_controller.js
+++ b/app/javascript/controllers/variation_controller.js
@@ -1,0 +1,133 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    'variationContainer',
+    'sizesContainer'
+  ]
+
+  connect() {
+    this.variationCounter = 0
+  }
+
+  addVariationField(e){
+    e.preventDefault()
+    const nameInput = this.createField('text', 'Input Name here...', 'product[variations_attributes][][name]')
+    const imageInput = this.createField('file', '', 'product[variations_attributes][][image]')
+    const cancelButton = this.createCancelButton()
+    const inputGrp = this.createFieldContainer('border m-1 border-gray-300 rounded p-2 flex items-center justify-around')
+    const variationContainer = this.createFieldContainer('relative m-1 bg-gray-100 border-2 border-gray-500 rounded p-2 items-center justify-around')
+    const sizeButton = document.createElement('button')
+
+    imageInput.setAttribute('accept', 'image/png, image/jpeg')
+    imageInput.setAttribute('class', 'variation-image-input')
+
+    this.variationCounter += 1
+    const sizeContainer = this.createFieldContainer('', `sizeContainer${this.variationCounter}`)
+    sizeContainer.setAttribute('id', `sizeContainer${this.variationCounter}`)
+
+    sizeButton.innerText = 'Add Size'
+    sizeButton.setAttribute('data-action', 'click->variation#addSizeFields')
+    sizeButton.setAttribute('data-size-button-index', this.variationCounter)
+    sizeButton.setAttribute('class', 'bg-gray-100 p-1 border m-1 rounded hover:shadow')
+
+    inputGrp.appendChild(nameInput)
+    inputGrp.appendChild(imageInput)
+    variationContainer.appendChild(inputGrp)
+    variationContainer.appendChild(sizeContainer)
+    variationContainer.appendChild(sizeButton)
+    variationContainer.appendChild(cancelButton)
+    
+    cancelButton.addEventListener('click', (e) => {
+      variationContainer.remove()
+    })
+
+    this.variationContainerTarget.appendChild(variationContainer)
+  }
+  
+  addSizeFields(e) {
+    if(e) e.preventDefault();
+
+    const sizeField = this.createField('text', 'Size', 'product[variations_attributes][][sizes_attributes][][size]')
+    sizeField.setAttribute('required', 'true')
+
+    const priceField = this.createField('number', 'Price', 'product[variations_attributes][][sizes_attributes][][price]')
+    const mainDetails = this.createFieldContainer('flex m-1')
+    mainDetails.appendChild(sizeField)
+    mainDetails.appendChild(priceField)
+
+    const widthField = this.createField('number', 'Width', 'product[variations_attributes][][sizes_attributes][][width]')
+    const lengthField = this.createField('number', 'Length', 'product[variations_attributes][][sizes_attributes][][length]')
+    const heightField = this.createField('number', 'Height', 'product[variations_attributes][][sizes_attributes][][height]')
+  
+    const dimensions = this.createFieldContainer('flex m-1')
+    dimensions.appendChild(lengthField)
+    dimensions.appendChild(widthField)
+    dimensions.appendChild(heightField)
+
+    const div = this.createFieldContainer('relative border m-1 rounded p-2')
+    div.appendChild(mainDetails)
+    div.appendChild(dimensions)
+
+    const cancelButton = document.createElement('span')
+    cancelButton.setAttribute('class', 'absolute -top-4 -right-4 ml-2 p-1 flex items-center justify-center rounded-full text-white bg-gray-300 hover:bg-gray-400 shadow hover:cursor-pointer')
+    cancelButton.style.width = '2rem'
+    cancelButton.style.height = '2rem'
+    cancelButton.innerText = 'x'
+    cancelButton.addEventListener('click', (e) => div.remove())
+
+    div.appendChild(cancelButton)
+    console.log(e.currentTarget.dataset)
+    console.log(e)
+    const container = document.getElementById(`sizeContainer${e.currentTarget.dataset.sizeButtonIndex}`)
+    container.appendChild(div)
+
+    console.log(this.data.get('index'))
+  }
+
+  createField(type, placeholder = '', name) {
+    const input = document.createElement('input')
+    input.setAttribute('type', type)
+    
+    if(['length', 'width', 'height'].includes(name)) {
+      input.setAttribute('placeholder', `${name} (cm)`)
+    } else {
+      input.setAttribute('placeholder', placeholder)
+    }
+
+    if(type == 'number') input.setAttribute('step', 'any')
+
+    input.setAttribute('name', name)
+    input.setAttribute('class', 'mx-2 border-0 border-b-2 border-black text-base h-14')
+
+    return input
+  }
+
+  removeField(e, sizeField) {
+    const key = e.code
+    const value = e.currentTarget.value
+    if (value.length > 0) return
+
+    if(key == 'Backspace' && sizeField) return sizeField.remove()
+
+    if(key == 'Backspace') return e.currentTarget.remove()
+  }
+
+  createCancelButton() {
+    const cancelButton = document.createElement('span')
+    cancelButton.setAttribute('class', 'absolute -top-4 -right-4 ml-2 p-1 flex items-center justify-center rounded-full text-white bg-gray-300 hover:bg-gray-400 shadow hover:cursor-pointer')
+    cancelButton.style.width = '2rem'
+    cancelButton.style.height = '2rem'
+    cancelButton.innerText = 'x'
+
+    return cancelButton
+  }
+
+  createFieldContainer(classList, id = null) {
+    const div = document.createElement('div')
+    div.setAttribute('class', classList)
+    if(id)  div.setAttribute('id', id)
+
+    return div
+  }
+}

--- a/app/javascript/controllers/variation_controller.js
+++ b/app/javascript/controllers/variation_controller.js
@@ -22,7 +22,6 @@ export default class extends Controller {
     imageInput.setAttribute('accept', 'image/png, image/jpeg')
     imageInput.setAttribute('class', 'variation-image-input')
 
-    this.variationCounter += 1
     const sizeContainer = this.createFieldContainer('', `sizeContainer${this.variationCounter}`)
     sizeContainer.setAttribute('id', `sizeContainer${this.variationCounter}`)
 
@@ -43,6 +42,7 @@ export default class extends Controller {
     })
 
     this.variationContainerTarget.appendChild(variationContainer)
+    this.variationCounter += 1
   }
   
   addSizeFields(e) {
@@ -51,14 +51,18 @@ export default class extends Controller {
     const sizeField = this.createField('text', 'Size', 'product[variations_attributes][][sizes_attributes][][size]')
     sizeField.setAttribute('required', 'true')
 
-    const priceField = this.createField('number', 'Price', 'product[variations_attributes][][sizes_attributes][][price]')
-    const mainDetails = this.createFieldContainer('flex m-1')
+    const priceField = this.createField('number', 'Price (Php)', 'product[variations_attributes][][sizes_attributes][][price]')
+    const weightField = this.createField('number', 'Weight (Kg)', 'product[variations_attributes][][sizes_attributes][][weight]')
+    const quantityField = this.createField('number', 'Quantity', 'product[variations_attributes][][sizes_attributes][][quantity]')
+    const mainDetails = this.createFieldContainer('grid grid-cols-2 gap-1 m-1')
     mainDetails.appendChild(sizeField)
     mainDetails.appendChild(priceField)
+    mainDetails.appendChild(weightField)
+    mainDetails.appendChild(quantityField)
 
-    const widthField = this.createField('number', 'Width', 'product[variations_attributes][][sizes_attributes][][width]')
-    const lengthField = this.createField('number', 'Length', 'product[variations_attributes][][sizes_attributes][][length]')
-    const heightField = this.createField('number', 'Height', 'product[variations_attributes][][sizes_attributes][][height]')
+    const widthField = this.createField('number', 'Width (cm)', 'product[variations_attributes][][sizes_attributes][][width]')
+    const lengthField = this.createField('number', 'Length (cm)', 'product[variations_attributes][][sizes_attributes][][length]')
+    const heightField = this.createField('number', 'Height (cm)', 'product[variations_attributes][][sizes_attributes][][height]')
   
     const dimensions = this.createFieldContainer('flex m-1')
     dimensions.appendChild(lengthField)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,15 +6,12 @@ class Product < ApplicationRecord
   has_rich_text :detail
   has_many_attached :images, dependent: :destroy
   belongs_to :category
-  has_many :sizes, dependent: :destroy
 
   paginates_per 15
 
   accepts_nested_attributes_for :variations
-  accepts_nested_attributes_for :sizes
   # Validations
 
   validates :name, presence: true, uniqueness: true
-  validates :price, presence: true
   validates :detail, presence: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,14 +1,17 @@
 class Product < ApplicationRecord
   has_many :orders
   has_many :customers, through: :orders
-  has_many :comments
-  has_many :variations
+  has_many :comments, dependent: :destroy
+  has_many :variations, dependent: :destroy
   has_rich_text :detail
-  has_many_attached :images
+  has_many_attached :images, dependent: :destroy
   belongs_to :category
+  has_many :sizes, dependent: :destroy
 
   paginates_per 15
 
+  accepts_nested_attributes_for :variations
+  accepts_nested_attributes_for :sizes
   # Validations
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,4 +1,4 @@
 class Size < ApplicationRecord
-  belongs_to :product
-  validates :size, uniqueness: { scope: :product, message: 'should be unique per product' }
+  belongs_to :sizable, polymorphic: true
+  validates :size, uniqueness: { scope: :sizable, message: 'should be unique per product' }
 end

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,0 +1,4 @@
+class Size < ApplicationRecord
+  belongs_to :product
+  validates :size, uniqueness: { scope: :product, message: 'should be unique per product' }
+end

--- a/app/models/variation.rb
+++ b/app/models/variation.rb
@@ -1,4 +1,7 @@
 class Variation < ApplicationRecord
   belongs_to :product
+  has_many :sizes, as: :sizable, dependent: :destroy
   has_one_attached :image, dependent: :destroy
+
+  accepts_nested_attributes_for :sizes, allow_destroy: true
 end

--- a/app/views/admin_console/products/_form.html.erb
+++ b/app/views/admin_console/products/_form.html.erb
@@ -4,29 +4,15 @@
     <%= f.text_field :name , class: 'w-full border-gray-700 border-0 border-b-2 bg-gray-50'%>
   </div>
 
-  <div class="input-group flex justify-between" data-controller="products">
-    <div>
-      <div class="my-8">
-        <%= f.label :price %><br />
-        <%= f.number_field :price, step: :any, class: 'w-64 border-gray-700 border-0 border-b bg-gray-50'%>
-      </div>
-
-      <div class="my-8">
-        <%= f.check_box :featured, class: 'border-gray-700 border rounded bg-gray-50'%>
-        <%= f.label :featured %>
-      </div>
+  <div class="input-group flex" data-controller="products">
+    <div class="my-8">
+      <%= f.label :category_id %><br />
+      <%= collection_select(:product, :category_id, Category.all, :id, :name, {prompt: true}, {class: 'w-full border-0 border-b bg-gray-50'})%>
     </div>
 
-    <div>
-      <div class="my-8">
-        <%= f.label :quantity %><br />
-        <%= f.number_field :quantity, class: 'w-64 border-gray-700 border-0 border-b bg-gray-50' %>
-      </div>
-
-      <div class="my-8">
-        <%= f.label :category_id %><br />
-        <%= collection_select(:product, :category_id, Category.all, :id, :name, {prompt: true}, {class: 'w-full border-0 border-b bg-gray-50'})%>
-      </div>
+    <div class="my-8 mx-5 flex items-center">
+      <%= f.check_box :featured %>
+      <%= f.label :featured, class: 'mx-1 hover:cursor-pointer' %>
     </div>
   </div>
   
@@ -41,23 +27,15 @@
     <div id="image-previews" class="grid grid-cols-2 gap-1 w-96 overflow-y-auto" data-previews-target="previewContainer"></div>
   </div>
 
-  <div class="input-group my-8" data-controller="products">
-    <div class="my-8">
-        <label>Sizes</label><br/>
-        <div data-products-target="sizesContainer" class="my-1">
-          <div>
-            
-          </div>
-        </div>
-
-        <button class="bg-gray-100 p-1 border m-1 rounded hover:shadow" data-action="click->products#addSizeFields">Add Size</button>
-      </div>
+  <div class="input-group field">
+    <label>Detail</label><br />
+    <%= f.rich_text_area :detail %>
   </div>
 
-  <div class="input-group my-8" data-controller="products">
+  <div class="input-group my-8" data-controller="variation">
     <label>Variations</label><br>
-    <div data-products-target="variationContainer" class="my-1">
-      
+    <div data-variation-target="variationContainer" class="my-1">
+
       <% if @product.variations.present? %>
         <div class="grid grid-cols-4 gap-2">
 
@@ -80,22 +58,16 @@
           <% end %>
 
         </div>
-
       <% end %>
 
     </div>
     <button type="button" 
       class="border-2 border-dashed rounded border-gray-500 text-gray-800 text-xl bg-gray-100 w-full h-24"
-      data-action="click->products#addVariationField" >
+      data-action="click->variation#addVariationField" >
       Add Variation
     </button>
 
     <br>
-  </div>
-
-  <div class="input-group field">
-    <label>Detail</label><br />
-    <%= f.rich_text_area :detail %>
   </div>
   
   <div class="my-2 flex justify-end">

--- a/app/views/admin_console/products/_form.html.erb
+++ b/app/views/admin_console/products/_form.html.erb
@@ -11,18 +11,9 @@
         <%= f.number_field :price, step: :any, class: 'w-64 border-gray-700 border-0 border-b bg-gray-50'%>
       </div>
 
-      <div class="my-8 w-64">
-        <label>Sizes</label><br/>
-        <div data-products-target="sizesContainer" class="my-1">
-          <% product&.sizes.each do |size| %>
-            <input class="m-1 w-1/3 border-gray-700 border-0 border-b-2 bg-gray-50"
-              type="text"
-              name="product[sizes][]"
-              value="<%= size %>"
-              data-action="keydown->products#removeField">
-          <% end %>
-        </div>
-        <button class="bg-gray-100 p-1 border m-1 rounded hover:shadow" data-action="click->products#addSize">Add Size</button>
+      <div class="my-8">
+        <%= f.check_box :featured, class: 'border-gray-700 border rounded bg-gray-50'%>
+        <%= f.label :featured %>
       </div>
     </div>
 
@@ -48,6 +39,19 @@
     %>
 
     <div id="image-previews" class="grid grid-cols-2 gap-1 w-96 overflow-y-auto" data-previews-target="previewContainer"></div>
+  </div>
+
+  <div class="input-group my-8" data-controller="products">
+    <div class="my-8">
+        <label>Sizes</label><br/>
+        <div data-products-target="sizesContainer" class="my-1">
+          <div>
+            
+          </div>
+        </div>
+
+        <button class="bg-gray-100 p-1 border m-1 rounded hover:shadow" data-action="click->products#addSizeFields">Add Size</button>
+      </div>
   </div>
 
   <div class="input-group my-8" data-controller="products">

--- a/app/views/admin_console/products/show.html.erb
+++ b/app/views/admin_console/products/show.html.erb
@@ -14,30 +14,32 @@
       <span class="">PHP <%= @product.price %></span>
     </div>
 
-    <div class="text-lg my-5">
-      <h2 class="font-semibold tracking-wide">VARIANTS:</h2>
-      <div class="grid grid-cols-4 gap-2">
-        <% @product.variations.each do |variant|%>
-          <div class="border p-0">
-            <%if variant.image.attached?%>
-              <%= image_tag variant.image, class: 'h-24 mx-auto'%>
-            <%else%>
-              <div class="flex bg-gray-200 h-24 items-center text-center justify-center text-gray-500">
-                <h2>Missing Image</h2>
-              </div>
-            <%end%>
+    <% if @product.variations.exists? %>
+      <div class="text-lg my-5">
+        <h2 class="font-semibold tracking-wide">VARIANTS:</h2>
+        <div class="grid grid-cols-4 gap-2">
+          <% @product.variations.each do |variant|%>
+            <div class="border p-0 rounded">
+              <%if variant.image.attached?%>
+                <%= image_tag variant.image, class: 'h-24 mx-auto'%>
+              <%else%>
+                <div class="flex bg-gray-200 h-24 items-center text-center justify-center text-gray-500">
+                  <h2>Missing Image</h2>
+                </div>
+              <%end%>
 
-            <h3 class="p-1"><%= variant.name%></h3>
-          </div>
-        <%end%>
-      </div>
+              <h3 class="p-1"><%= variant.name%></h3>
+            </div>
+          <%end%>
+        </div>
+      <%end%>
     </div>
 
     <div class="text-md my-5">
       <h2 class="font-semibold tracking-wide">SIZES:</h2>
       <div class="flex">
         <% @product.sizes.each do |size| %>
-          <div class="border mx-2 p-2 rounded hover:cursor-pointer hover:border-purple-800"><%= size %></div>
+          <div class="border mx-2 p-2 rounded hover:cursor-pointer hover:border-purple-800"><%= size.size %></div>
         <% end %>
       </div>
     </div>

--- a/db/migrate/20230814135701_create_products.rb
+++ b/db/migrate/20230814135701_create_products.rb
@@ -3,8 +3,6 @@ class CreateProducts < ActiveRecord::Migration[7.0]
     create_table :products do |t|
       t.string :name
       t.boolean :featured
-      t.decimal :price, precision: 10, scale: 2
-      t.decimal :quantity, precision: 10, scale: 2
       t.timestamps
     end
   end

--- a/db/migrate/20230814135701_create_products.rb
+++ b/db/migrate/20230814135701_create_products.rb
@@ -2,7 +2,6 @@ class CreateProducts < ActiveRecord::Migration[7.0]
   def change
     create_table :products do |t|
       t.string :name
-      t.text :sizes, array: true, default: []
       t.boolean :featured
       t.decimal :price, precision: 10, scale: 2
       t.decimal :quantity, precision: 10, scale: 2

--- a/db/migrate/20231011154908_create_variations.rb
+++ b/db/migrate/20231011154908_create_variations.rb
@@ -3,7 +3,6 @@ class CreateVariations < ActiveRecord::Migration[7.0]
     create_table :variations do |t|
       t.belongs_to :product
       t.string :name
-      t.decimal :price, precision: 10, scale: 2
       t.timestamps
     end
   end

--- a/db/migrate/20231019034243_create_sizes.rb
+++ b/db/migrate/20231019034243_create_sizes.rb
@@ -4,6 +4,7 @@ class CreateSizes < ActiveRecord::Migration[7.0]
       t.references :sizable, polymorphic: true
       t.string :size, null: false
       t.integer :quantity, precision: 10, scale: 2
+      t.decimal :weight, precision: 10, scale: 2
       t.decimal :price, precision: 10, scale: 2
       t.decimal :width, precision: 10, scale: 2
       t.decimal :length, precision: 10, scale: 2

--- a/db/migrate/20231019034243_create_sizes.rb
+++ b/db/migrate/20231019034243_create_sizes.rb
@@ -1,8 +1,9 @@
 class CreateSizes < ActiveRecord::Migration[7.0]
   def change
     create_table :sizes do |t|
-      t.references :product
+      t.references :sizable, polymorphic: true
       t.string :size, null: false
+      t.integer :quantity, precision: 10, scale: 2
       t.decimal :price, precision: 10, scale: 2
       t.decimal :width, precision: 10, scale: 2
       t.decimal :length, precision: 10, scale: 2

--- a/db/migrate/20231019034243_create_sizes.rb
+++ b/db/migrate/20231019034243_create_sizes.rb
@@ -1,0 +1,13 @@
+class CreateSizes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sizes do |t|
+      t.references :product
+      t.string :size, null: false
+      t.decimal :price, precision: 10, scale: 2
+      t.decimal :width, precision: 10, scale: 2
+      t.decimal :length, precision: 10, scale: 2
+      t.decimal :height, precision: 10, scale: 2
+      t.timestamps
+    end
+  end
+end

--- a/test/fixtures/sizes.yml
+++ b/test/fixtures/sizes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value


### PR DESCRIPTION
Make product sizes into a separate model instead of a column of product.
To add more information for sizes such as dimensions (width, length & height) and price depending on the size of product.