### PR TITLE
Admin Console Edit Variation Size

### DIFF
--- a/app/controllers/admin_console/sizes_controller.rb
+++ b/app/controllers/admin_console/sizes_controller.rb
@@ -33,6 +33,32 @@ class AdminConsole::SizesController < AdminController
     end
   end
 
+  def destroy
+    size.destroy
+
+    if size.destroyed?
+      respond_to do |format|
+        format.html do
+          redirect_to admin_console_product_variation_path(product, variation), notice: 'Successfully deleted size!'
+        end
+        format.turbo_stream do
+          flash[:notice] = 'Successfully deleted size!'
+          render :destroy, locals: { size: size }
+        end
+      end
+    else
+      respond_to do |format|
+        format.html do
+          redirect_to admin_console_product_variation_path(product, variation), alert: size.errors.full_messages
+        end
+        format.turbo_stream do
+          flash[:alert] = size.errors.full_messages
+          render :destroy, locals: { size: nil }
+        end
+      end
+    end
+  end
+
   private
 
   def size_params

--- a/app/controllers/admin_console/sizes_controller.rb
+++ b/app/controllers/admin_console/sizes_controller.rb
@@ -2,4 +2,54 @@ class AdminConsole::SizesController < AdminController
   def index
     @sizes = Size.where(sizable_id: params[:sizable_id], sizable_type: params[:sizable_type])
   end
+
+  def edit
+    @size = Size.find params[:id]
+  end
+
+  def update
+    @size = Size.find params[:id]
+
+    if @size.update(size_params)
+      respond_to do |format|
+        format.html do
+          redirect_to admin_console_product_variation_path(product, variation), notice: 'Succesfully update variation size'
+        end
+        format.turbo_stream do
+          flash.now[:notice] = 'Size successfully updated!'
+          render :update, locals: { size: @size }
+        end
+      end
+    else
+      respond_to do |format|
+        format.html do
+          redirect_to edit_admin_console_size_path(@size), alert: @size.errors.full_messages
+        end
+        format.turbo_stream do
+          flash[:alert] = @size.errors.full_messages
+          render :update, locals: { size: @size }
+        end
+      end
+    end
+  end
+
+  private
+
+  def size_params
+    params.require(:size).permit(:size, :quantity, :length, :width, :height)
+  end
+
+  def size
+    @size ||= Size.find params[:id]
+  end
+
+  def variation
+    return if size.sizable_type != 'Variation'
+
+    @variation ||= Variation.find size.sizable_id
+  end
+
+  def product
+    @product ||= variation.product
+  end
 end

--- a/app/controllers/admin_console/sizes_controller.rb
+++ b/app/controllers/admin_console/sizes_controller.rb
@@ -3,6 +3,38 @@ class AdminConsole::SizesController < AdminController
     @sizes = Size.where(sizable_id: params[:sizable_id], sizable_type: params[:sizable_type])
   end
 
+  def new
+    @size = Size.new
+    @sizable_id = params[:sizable_id]
+    @sizable_type = params[:sizable_type]
+  end
+
+  def create
+    hash = { sizable_id: params.dig(:size, :sizable_id), sizable_type: params.dig(:size, :sizable_type) }
+    @size = Size.new(size_params.merge(hash))
+    if @size.valid? && @size.save
+      respond_to do |format|
+        format.html do
+          redirect_to admin_console_product_variation_path(product, variation), notice: 'Successfully create variation size'
+        end
+        format.turbo_stream do
+          flash.now[:notice] = 'Successfully create variation size'
+          render :create, locals: { size: @size }
+        end
+      end
+    else
+      respond_to do |format|
+        format.html do
+          redirect_to admin_console_product_variation_path(product, variation), alert: @size.errors.full_messages
+        end
+        format.turbo_stream do
+          flash.now[:alert] = @size.errors.full_messages
+          render :create, locals: { size: nil }
+        end
+      end
+    end
+  end
+
   def edit
     @size = Size.find params[:id]
   end

--- a/app/controllers/admin_console/sizes_controller.rb
+++ b/app/controllers/admin_console/sizes_controller.rb
@@ -59,7 +59,7 @@ class AdminConsole::SizesController < AdminController
         end
         format.turbo_stream do
           flash[:alert] = @size.errors.full_messages
-          render :update, locals: { size: @size }
+          render :update, locals: { size: nil }
         end
       end
     end

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,4 +1,5 @@
 class Size < ApplicationRecord
   belongs_to :sizable, polymorphic: true
+  validates :size, presence: true
   validates :size, uniqueness: { scope: :sizable, message: 'should be unique per product' }
 end

--- a/app/views/admin_console/sizes/_form.html.erb
+++ b/app/views/admin_console/sizes/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_with model: size, url: url, class: 'p-10 bg-white shadow rounded' do |f| %>
+  <div class="my-5 flex justify-between">
+    <div class="hidden">
+      <%= f.number_field :sizable_id, value: sizable_id, class: 'hidden'%>
+      <%= f.text_field :sizable_type, value: sizable_type, class: 'hidden'%>
+    </div>
+
+    <div class="">
+      <%= f.label :size %><br/>
+      <%= f.text_field :size%>
+    </div>
+
+    <div>
+      <%= f.label :quantity %><br/>
+      <%= f.number_field :quantity%>
+    </div>
+  </div>
+
+  <h1>Dimensions</h1>
+  <div class="flex my-5">
+    <div class="mx-1">
+      <%= f.label :length %><br/>
+      <%= f.number_field :length, step: 'any'%>
+    </div>
+
+    <div class="mx-1">
+      <%= f.label :width %><br/>
+      <%= f.number_field :width, step: 'any'%>
+    </div>
+
+    <div class="mx-1">
+      <%= f.label :height %><br/>
+      <%= f.number_field :height, step: 'any'%>
+    </div>
+  </div>
+
+  <div data-controller="modals" class="my-5 flex justify-end">
+    <%= f.submit "Submit", disable_with: 'Submiting...',
+      class: 'mx-1 bg-green-400 text-white p-2 rounded shadow hover:bg-green-600 cursor-pointer'
+    %>
+    <%= link_to "Cancel", '', data: { action: 'modals#close' },
+      class: 'mx-1 bg-red-400 text-white p-2 rounded shadow hover:bg-red-600'
+    %>
+  </div>
+<%end%>

--- a/app/views/admin_console/sizes/_form.html.erb
+++ b/app/views/admin_console/sizes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: size, url: url, class: 'p-10 bg-white shadow rounded' do |f| %>
+<%= form_with model: size, url: url, id: 'size_form', class: 'relative p-10 bg-white shadow rounded' do |f| %>
   <div class="my-5 flex justify-between">
     <div class="hidden">
       <%= f.number_field :sizable_id, value: sizable_id, class: 'hidden'%>

--- a/app/views/admin_console/sizes/create.turbo_stream.erb
+++ b/app/views/admin_console/sizes/create.turbo_stream.erb
@@ -1,0 +1,25 @@
+<% if size.present? %>
+  <%= turbo_stream.update 'modal' do %>
+  <% end %>
+  <%= turbo_stream.append 'sizes-table-body' do %>
+    <tr id=<%= %"size_#{size.id}"%> class="border-b border-gray-400 hover:bg-gray-100 hover:cursor-default">
+      <td class="p-2"><%= size.size %></td>
+      <td class="p-2"><%= size.price %></td>
+      <td class="p-2"><%= size.quantity %></td>
+
+      <td class="p-2"><%= size.length %></td>
+      <td class="p-2"><%= size.width %></td>
+      <td class="p-2"><%= size.height %></td>
+
+      <td class="">
+        <%= link_to edit_admin_console_size_path(size), data: { turbo_frame: 'modal' } do %>
+          <i class="fa-regular fa-pen-to-square"></i>
+        <% end %>
+
+        <%= link_to admin_console_size_path(size), data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do %>
+          <i class="fa-solid fa-trash"></i>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/admin_console/sizes/create.turbo_stream.erb
+++ b/app/views/admin_console/sizes/create.turbo_stream.erb
@@ -1,6 +1,13 @@
 <% if size.present? %>
   <%= turbo_stream.update 'modal' do %>
   <% end %>
+
+  <%= turbo_stream.prepend 'size-container' do %>
+    <div class='absolute top-0 left-0'>
+      <%= render partial: 'partials/flash_messages'%>
+    </div>
+  <%end%>
+
   <%= turbo_stream.append 'sizes-table-body' do %>
     <tr id=<%= %"size_#{size.id}"%> class="border-b border-gray-400 hover:bg-gray-100 hover:cursor-default">
       <td class="p-2"><%= size.size %></td>
@@ -22,4 +29,10 @@
       </td>
     </tr>
   <% end %>
+<% else %>
+  <%= turbo_stream.prepend 'size_form' do %>
+    <div class='absolute top-0 left-0'>
+      <%= render partial: 'partials/flash_messages'%>
+    </div>
+  <%end%>
 <% end %>

--- a/app/views/admin_console/sizes/destroy.turbo_stream.erb
+++ b/app/views/admin_console/sizes/destroy.turbo_stream.erb
@@ -1,0 +1,10 @@
+<% if size.present? %>
+  <%= turbo_stream.prepend 'size-container' do %>
+    <div class='absolute top-0 left-0'>
+      <%= render partial: 'partials/flash_messages'%>
+    </div>
+  <%end%>
+  <%= turbo_stream.remove "size_#{size.id}"%>
+<% else %>
+  <%= %>
+<% end %>

--- a/app/views/admin_console/sizes/edit.html.erb
+++ b/app/views/admin_console/sizes/edit.html.erb
@@ -1,0 +1,44 @@
+<%= turbo_frame_tag 'modal' do %>
+  <div class="flex justify-center items-center fixed top-0 z-30 w-screen h-screen bg-gray-500 bg-opacity-20">
+    <%= form_with model: @size, url: admin_console_size_path(@size), class: 'p-10 bg-white shadow rounded' do |f| %>
+      <div class="my-5 flex justify-between">
+        <div class="">
+          <%= f.label :size %><br/>
+          <%= f.text_field :size%>
+        </div>
+
+        <div>
+          <%= f.label :quantity %><br/>
+          <%= f.number_field :quantity%>
+        </div>
+      </div>
+
+      <h1>Dimensions</h1>
+      <div class="flex my-5">
+        <div class="mx-1">
+          <%= f.label :length %><br/>
+          <%= f.number_field :length, step: 'any'%>
+        </div>
+
+        <div class="mx-1">
+          <%= f.label :width %><br/>
+          <%= f.number_field :width, step: 'any'%>
+        </div>
+
+        <div class="mx-1">
+          <%= f.label :height %><br/>
+          <%= f.number_field :height, step: 'any'%>
+        </div>
+      </div>
+
+      <div data-controller="modals" class="my-5 flex justify-end">
+        <%= f.submit "Submit", disable_with: 'Submiting...',
+          class: 'mx-1 bg-green-400 text-white p-2 rounded shadow hover:bg-green-600 cursor-pointer'
+        %>
+        <%= link_to "Cancel", '', data: { action: 'modals#close' },
+          class: 'mx-1 bg-red-400 text-white p-2 rounded shadow hover:bg-red-600'
+        %>
+      </div>
+    <%end%>
+  </div>
+<%end%>

--- a/app/views/admin_console/sizes/new.html.erb
+++ b/app/views/admin_console/sizes/new.html.erb
@@ -2,10 +2,10 @@
   <div class="flex justify-center items-center fixed top-0 z-30 w-screen h-screen bg-gray-500 bg-opacity-20">
     <%= render partial: 'form', locals: {
         size: @size,
-        sizable_id: nil,
-        sizable_type: nil,
-        url: admin_console_size_path(@size)
+        sizable_id: @sizable_id,
+        sizable_type: @sizable_type,
+        url: admin_console_sizes_path
       }
     %>
   </div>
-<%end%>
+<% end %>

--- a/app/views/admin_console/sizes/update.turbo_stream.erb
+++ b/app/views/admin_console/sizes/update.turbo_stream.erb
@@ -28,5 +28,10 @@
     </td>
   <% end %>
 
-
+<% else %>
+  <%= turbo_stream.prepend 'size_form' do %>
+    <div class='absolute top-0 left-0'>
+      <%= render partial: 'partials/flash_messages'%>
+    </div>
+  <%end%>
 <% end %>

--- a/app/views/admin_console/sizes/update.turbo_stream.erb
+++ b/app/views/admin_console/sizes/update.turbo_stream.erb
@@ -1,0 +1,26 @@
+<% if size.present? %>
+  <%= turbo_stream.update 'modal' do %>
+  <% end %>
+
+  <%= turbo_stream.update "size_#{size.id}" do %>
+    <td class="p-2"><%= size.size %></td>
+    <td class="p-2"><%= size.price %></td>
+    <td class="p-2"><%= size.quantity %></td>
+
+    <td class="p-2"><%= size.length %></td>
+    <td class="p-2"><%= size.width %></td>
+    <td class="p-2"><%= size.height %></td>
+
+    <td class="">
+      <%= link_to edit_admin_console_size_path(size), data: { turbo_frame: 'modal' } do %>
+        <i class="fa-regular fa-pen-to-square"></i>
+      <% end %>
+
+      <%= link_to admin_console_size_path(size), data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do %>
+        <i class="fa-solid fa-trash"></i>
+      <% end %>
+    </td>
+  <% end %>
+
+
+<% end %>

--- a/app/views/admin_console/sizes/update.turbo_stream.erb
+++ b/app/views/admin_console/sizes/update.turbo_stream.erb
@@ -1,4 +1,10 @@
 <% if size.present? %>
+  <%= turbo_stream.prepend 'size-container' do %>
+    <div class='absolute top-0 left-0'>
+      <%= render partial: 'partials/flash_messages'%>
+    </div>
+  <%end%>
+
   <%= turbo_stream.update 'modal' do %>
   <% end %>
 

--- a/app/views/admin_console/variations/show.html.erb
+++ b/app/views/admin_console/variations/show.html.erb
@@ -5,7 +5,14 @@
     <%= render partial: 'variation_show_block', locals: { variation: @variation }%>
   <%end%>
 
-  <div id="size-container" class="table-container flex justify-center my-8">
+  <div id="size-container" class="table-container flex flex-col items-center justify-center my-8">
+    <div class="flex justify-end w-7/12 py-2">
+      <%= link_to 'Add Size', new_admin_console_size_path(sizable_id: @variation.id, sizable_type: 'Variation'),
+        class: 'p-2 bg-yellow-500 text-white rounded shadow hover:bg-yellow-600',
+        data: { turbo_frame: 'modal' }
+      %>
+    </div>
+
     <table id="sizes-table" class="table w-7/12">
       <tr class="text-md border rounded-top bg-gray-100">
         <th class="p-2" rowspan="2">Size</th>
@@ -20,7 +27,7 @@
         <td class="p-2">Height</td>
       </tr>
 
-      <tbody>
+      <tbody id="sizes-table-body">
         <% @variation.sizes.each do |size| %>
           <tr id=<%= %"size_#{size.id}"%> class="border-b border-gray-400 hover:bg-gray-100 hover:cursor-default">
             <td class="p-2"><%= size.size %></td>

--- a/app/views/admin_console/variations/show.html.erb
+++ b/app/views/admin_console/variations/show.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'variation_show_block', locals: { variation: @variation }%>
   <%end%>
 
-  <div class="table-container flex justify-center my-8">
+  <div id="size-container" class="table-container flex justify-center my-8">
     <table id="sizes-table" class="table w-7/12">
       <tr class="text-md border rounded-top bg-gray-100">
         <th class="p-2" rowspan="2">Size</th>

--- a/app/views/admin_console/variations/show.html.erb
+++ b/app/views/admin_console/variations/show.html.erb
@@ -6,7 +6,7 @@
   <%end%>
 
   <div class="table-container flex justify-center my-8">
-    <table class="w-7/12">
+    <table id="sizes-table" class="table w-7/12">
       <tr class="text-md border rounded-top bg-gray-100">
         <th class="p-2" rowspan="2">Size</th>
         <th class="p-2" rowspan="2">Price</th>
@@ -22,7 +22,7 @@
 
       <tbody>
         <% @variation.sizes.each do |size| %>
-          <tr class="border-b border-gray-400 hover:bg-gray-100 hover:cursor-default">
+          <tr id=<%= %"size_#{size.id}"%> class="border-b border-gray-400 hover:bg-gray-100 hover:cursor-default">
             <td class="p-2"><%= size.size %></td>
             <td class="p-2"><%= size.price %></td>
             <td class="p-2"><%= size.quantity %></td>
@@ -32,7 +32,7 @@
             <td class="p-2"><%= size.height %></td>
 
             <td class="">
-              <%= link_to edit_admin_console_size_path(size) do %>
+              <%= link_to edit_admin_console_size_path(size), data: { turbo_frame: 'modal' } do %>
                 <i class="fa-regular fa-pen-to-square"></i>
               <% end %>
 


### PR DESCRIPTION
Add New and Edit modal for variation size on admin console in variation page.
Feature includes create, update and delete functionality with turbo stream.

## Add Size button
<img width="1085" alt="Screenshot 2023-11-21 at 10 06 02 PM" src="https://github.com/TheEyePatch/giszmo-boutique/assets/76772310/d4c06d1c-7549-4ae8-9ec6-838d80cdfa42">


## New and Edit form
<img width="1143" alt="Screenshot 2023-11-21 at 10 06 23 PM" src="https://github.com/TheEyePatch/giszmo-boutique/assets/76772310/b20b933d-0064-4cd0-ae42-e98a1e38de11">

